### PR TITLE
fix(lcms2): CVE-2026-41254

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lcms2 (2.14-2deepin2) unstable; urgency=medium
+
+  * Fix CVE-2026-41254: CubeSize integer overflow in cmslut.c
+  * CVE-2026-42798: not-affected (vulnerable code not in 2.14)
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 04 Jun 2026 09:00:00 +0800
+
 lcms2 (2.14-2deepin1) unstable; urgency=medium
 
   * Security: CVE-2025-29070, fix heap buffer overflow in smooth2()

--- a/debian/patches/CVE-2026-41254.patch
+++ b/debian/patches/CVE-2026-41254.patch
@@ -1,0 +1,14 @@
+Index: lcms2/src/cmslut.c
+===================================================================
+--- lcms2.orig/src/cmslut.c
++++ lcms2/src/cmslut.c
+@@ -460,7 +460,8 @@ void EvaluateCLUTfloatIn16(const cmsFloa
+ static
+ cmsUInt32Number CubeSize(const cmsUInt32Number Dims[], cmsUInt32Number b)
+ {
+-    cmsUInt32Number rv, dim;
++    cmsUInt32Number dim;
++    cmsUInt64Number rv;
+ 
+     _cmsAssert(Dims != NULL);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ fix-memory-corruption-when-unregistering-plugins.diff
 manpages-cleanup.patch
 allow-to-read-portions-of-tag.diff
 cve-2025-29070-bound-check.patch
+CVE-2026-41254.patch


### PR DESCRIPTION
Fix CubeSize integer overflow in cmslut.c.
CVE-2026-42798: not-affected (vulnerable code not present in 2.14).

Upstream: https://github.com/mm2/Little-CMS/commit/da6110b1d14abc394633a388209abd5ebedd7ab0

Co-Authored-By: hudeng <hudeng@deepin.org>
Fix-Approach: patch
Generated-By: deepseek-v4-flash