### PR TITLE
feat: restore deepin patches on lcms2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lcms2 (2.16-2+deb13u2deepin1) unstable; urgency=medium
+
+  * Restore deepin patches on top of 2.16-2+deb13u2
+    - cve-2025-29070-bound-check.patch: add bound checker for smooth2 to fix heap buffer overflow
+
+ -- lichenggang <lichenggang@deepin.org>  Fri, 17 Jul 2026 23:48:00 +0800
+
 lcms2 (2.16-2+deb13u2) trixie-security; urgency=medium
 
   * CVE-2026-42798 (Closes: #1135320)
@@ -199,7 +206,7 @@ lcms2 (2.7-1) unstable; urgency=medium
   * Use secure URLs for Version Control System repository
   * Bump Standards version to 3.9.7, no changes needed
   * New patch: dont-write-uninitialized-memory-for-color-strings.patch
-    Thanks to Jérémy Bobbio <lunar@debian.org> (Closes: 815248)
+    Thanks to Jer\'{e}my Bobbio <lunar@debian.org> (Closes: 815248)
   * Update maintainers field (Closes: 820138)
 
  -- Thomas Weber <tweber@debian.org>  Mon, 18 Apr 2016 15:53:10 +0200

--- a/debian/patches/cve-2025-29070-bound-check.patch
+++ b/debian/patches/cve-2025-29070-bound-check.patch
@@ -1,0 +1,27 @@
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Tue, 4 Mar 2025 09:24:03 +0000
+Subject: Add a bound checker per #475
+
+Added a check for trying to smooth tables with less that 4 elements or
+by using lambda value close to zero.
+
+This fixes CVE-2025-29070: heap buffer overflow in smooth2() function.
+
+Origin: upstream, https://github.com/mm2/Little-CMS/commit/ec399d6879184e92a88c9099c60573f35e82e28b
+Bug: https://github.com/mm2/Little-CMS/issues/475
+---
+ src/cmsgamma.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cmsgamma.c b/src/cmsgamma.c
+index 94c0aef..9e12ebb 100644
+--- a/src/cmsgamma.c
++++ b/src/cmsgamma.c
+@@ -1144,6 +1144,7 @@ cmsBool smooth2(cmsContext ContextID, cmsFloat32Number w[], cmsFloat32Number y[]
+     cmsFloat32Number *c, *d, *e;
+     cmsBool st;
+ 
++    if (m < 4 || lambda < MATRIX_DET_TOLERANCE) return FALSE;
+ 
+     c = (cmsFloat32Number*) _cmsCalloc(ContextID, MAX_NODES_IN_CURVE, sizeof(cmsFloat32Number));
+     d = (cmsFloat32Number*) _cmsCalloc(ContextID, MAX_NODES_IN_CURVE, sizeof(cmsFloat32Number));

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,5 +3,6 @@ manpages-cleanup.patch
 unbreak-API-compatibility.patch
 build-plugins-as-static-libraries-only.patch
 keep-src-tree-clean.patch
+cve-2025-29070-bound-check.patch
 CVE-2026-41254.patch
 CVE-2026-42798.patch


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
- CVE-2025-29070 bound check patch

Related: automated backport of deepin patches.