### PR TITLE
feat: restore deepin patches on top of 2.16-2+deb13u2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lcms2 (2.16-2+deb13u2deepin1) unstable; urgency=medium
+
+  * Backport CVE-2025-29070 bound check patch from master branch
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 21 Jul 2026 21:13:20 +0800
+
 lcms2 (2.16-2+deb13u2) trixie-security; urgency=medium
 
   * CVE-2026-42798 (Closes: #1135320)

--- a/debian/patches/cve-2025-29070-bound-check.patch
+++ b/debian/patches/cve-2025-29070-bound-check.patch
@@ -1,0 +1,27 @@
+From: Marti Maria <marti.maria@littlecms.com>
+Date: Tue, 4 Mar 2025 09:24:03 +0000
+Subject: Add a bound checker per #475
+
+Added a check for trying to smooth tables with less that 4 elements or
+by using lambda value close to zero.
+
+This fixes CVE-2025-29070: heap buffer overflow in smooth2() function.
+
+Origin: upstream, https://github.com/mm2/Little-CMS/commit/ec399d6879184e92a88c9099c60573f35e82e28b
+Bug: https://github.com/mm2/Little-CMS/issues/475
+---
+ src/cmsgamma.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: lcms2/src/cmsgamma.c
+===================================================================
+--- lcms2.orig/src/cmsgamma.c
++++ lcms2/src/cmsgamma.c
+@@ -1158,6 +1158,7 @@ cmsBool smooth2(cmsContext ContextID, cm
+     cmsFloat32Number *c, *d, *e;
+     cmsBool st;
+ 
++    if (m < 4 || lambda < MATRIX_DET_TOLERANCE) return FALSE;
+ 
+     c = (cmsFloat32Number*) _cmsCalloc(ContextID, MAX_NODES_IN_CURVE, sizeof(cmsFloat32Number));
+     d = (cmsFloat32Number*) _cmsCalloc(ContextID, MAX_NODES_IN_CURVE, sizeof(cmsFloat32Number));

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ build-plugins-as-static-libraries-only.patch
 keep-src-tree-clean.patch
 CVE-2026-41254.patch
 CVE-2026-42798.patch
+cve-2025-29070-bound-check.patch


### PR DESCRIPTION
Restore cve-2025-29070-bound-check.patch: add bound checker for smooth2 to fix heap buffer overflow

Other deepin patches (fix-regression-for-CMYK-colours.patch, fix-memory-corruption-when-unregistering-plugins.diff, allow-to-read-portions-of-tag.diff) were already included upstream starting from version 2.16-1.